### PR TITLE
Set AssemblyCulture in AssemblyInfo to default

### DIFF
--- a/UFMailchimpWorkFlowType/Properties/AssemblyInfo.cs
+++ b/UFMailchimpWorkFlowType/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("UFMailchimpWorkFlowType")]
 [assembly: AssemblyCopyright("Copyright ©  2020")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("in")]
+[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
Changing AssemblyCulture to "" as "in" culture was causing an error on installation of the package
![image](https://user-images.githubusercontent.com/34098429/82338790-32610100-99e5-11ea-85a1-2088282cd383.png)
